### PR TITLE
fix: display name in policyAssignmentType2ArmPolicyAssignment function

### DIFF
--- a/internal/provider/archetype_data_source.go
+++ b/internal/provider/archetype_data_source.go
@@ -687,7 +687,11 @@ func policyAssignmentType2ArmPolicyAssignment(pamap map[string]PolicyAssignmentT
 		dst.ID = to.Ptr(fmt.Sprintf(policyAssignmentIdFmt, name))
 		dst.Name = to.Ptr(name)
 		dst.Type = to.Ptr(policyAssignementType)
-		dst.Properties.DisplayName = to.Ptr(src.DisplayName.ValueString())
+
+		// Set display name
+		if isKnown(src.DisplayName) {
+			dst.Properties.DisplayName = to.Ptr(src.DisplayName.ValueString())
+		}
 
 		// Set policy definition id.
 		if isKnown(src.PolicyDefinitionName) {

--- a/internal/provider/archetype_data_source_test.go
+++ b/internal/provider/archetype_data_source_test.go
@@ -321,6 +321,30 @@ func TestPolicyAssignmentType2ArmPolicyAssignment(t *testing.T) {
 			err:      nil,
 		},
 		{
+			name: "policy definition id and display name",
+			input: map[string]PolicyAssignmentType{
+				"test1": {
+					PolicyDefinitionName: types.StringValue("BlobServicesDiagnosticsLogsToWorkspace"),
+					DisplayName:          types.StringValue("BlobServicesDiagnosticsLogsToWorkspace"),
+				},
+			},
+			expected: map[string]*armpolicy.Assignment{
+				"test1": {
+					ID:   to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyAssignments/test1"),
+					Name: to.Ptr("test1"),
+					Type: to.Ptr("Microsoft.Authorization/policyAssignments"),
+					Properties: &armpolicy.AssignmentProperties{
+						DisplayName:           to.Ptr("BlobServicesDiagnosticsLogsToWorkspace"),
+						PolicyDefinitionID:    to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/BlobServicesDiagnosticsLogsToWorkspace"),
+						EnforcementMode:       nil,
+						NonComplianceMessages: []*armpolicy.NonComplianceMessage(nil),
+						Parameters:            map[string]*armpolicy.ParameterValuesValue(nil),
+					},
+				},
+			},
+			err: nil,
+		},
+		{
 			name: "policy definition id",
 			input: map[string]PolicyAssignmentType{
 				"test1": {
@@ -333,7 +357,7 @@ func TestPolicyAssignmentType2ArmPolicyAssignment(t *testing.T) {
 					Name: to.Ptr("test1"),
 					Type: to.Ptr("Microsoft.Authorization/policyAssignments"),
 					Properties: &armpolicy.AssignmentProperties{
-						DisplayName:           to.Ptr(""),
+						DisplayName:           nil,
 						PolicyDefinitionID:    to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/BlobServicesDiagnosticsLogsToWorkspace"),
 						EnforcementMode:       nil,
 						NonComplianceMessages: []*armpolicy.NonComplianceMessage(nil),
@@ -356,7 +380,7 @@ func TestPolicyAssignmentType2ArmPolicyAssignment(t *testing.T) {
 					Name: to.Ptr("test2"),
 					Type: to.Ptr("Microsoft.Authorization/policyAssignments"),
 					Properties: &armpolicy.AssignmentProperties{
-						DisplayName:           to.Ptr(""),
+						DisplayName:           nil,
 						PolicyDefinitionID:    to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policySetDefinitions/test"),
 						EnforcementMode:       nil,
 						NonComplianceMessages: []*armpolicy.NonComplianceMessage(nil),
@@ -380,7 +404,7 @@ func TestPolicyAssignmentType2ArmPolicyAssignment(t *testing.T) {
 					Name: to.Ptr("test3"),
 					Type: to.Ptr("Microsoft.Authorization/policyAssignments"),
 					Properties: &armpolicy.AssignmentProperties{
-						DisplayName:           to.Ptr(""),
+						DisplayName:           nil,
 						PolicyDefinitionID:    to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/BlobServicesDiagnosticsLogsToWorkspace"),
 						EnforcementMode:       to.Ptr(armpolicy.EnforcementModeDoNotEnforce),
 						NonComplianceMessages: []*armpolicy.NonComplianceMessage(nil),
@@ -408,7 +432,7 @@ func TestPolicyAssignmentType2ArmPolicyAssignment(t *testing.T) {
 					Name: to.Ptr("test4"),
 					Type: to.Ptr("Microsoft.Authorization/policyAssignments"),
 					Properties: &armpolicy.AssignmentProperties{
-						DisplayName:        to.Ptr(""),
+						DisplayName:        nil,
 						PolicyDefinitionID: to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/BlobServicesDiagnosticsLogsToWorkspace"),
 						EnforcementMode:    nil,
 						NonComplianceMessages: []*armpolicy.NonComplianceMessage{
@@ -439,7 +463,7 @@ func TestPolicyAssignmentType2ArmPolicyAssignment(t *testing.T) {
 					Name: to.Ptr("test5"),
 					Type: to.Ptr("Microsoft.Authorization/policyAssignments"),
 					Properties: &armpolicy.AssignmentProperties{
-						DisplayName:           to.Ptr(""),
+						DisplayName:           nil,
 						PolicyDefinitionID:    to.Ptr("/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policyDefinitions/BlobServicesDiagnosticsLogsToWorkspace"),
 						EnforcementMode:       nil,
 						NonComplianceMessages: []*armpolicy.NonComplianceMessage(nil),


### PR DESCRIPTION
This pull request fixes an issue where the display name was not being properly set in the policyAssignmentType2ArmPolicyAssignment function. The fix involves checking if the display name is known before setting it in the destination properties. This change ensures that the display name is properly set for policy assignments.

fixes #30