### PR TITLE
feat: expose alz_lib_ref to allow user selection of tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,43 +5,43 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - freebsd
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -52,9 +52,26 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: false
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "Doc updates"
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      order: 999
+  filters:
+    include:
+      - "^feat:"
+      - "^fix:"
+      - "^docs:"

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ Use the navigation to the left to read about the available resources.
 ```terraform
 provider "alz" {
   lib_urls = [
-    "${path.root}/lib"
+    "${path.root}/lib",
+    "github.com/MyOrg/MyRepo//some/dir?ref=v1.1.0&depth=1",
   ]
 }
 ```
@@ -64,6 +65,7 @@ provider versions on the minor version.
 ### Optional
 
 - `allow_lib_overwrite` (Boolean) Whether to allow overwriting of library artifacts by subsequent libraries. Default is `false`.
+- `alz_lib_ref` (String) The reference to the ALZ library to use. Default (for now) is `main`.
 - `auxiliary_tenant_ids` (List of String) A list of auxiliary tenant ids which should be used. If not specified, value will be attempted to be read from the `ARM_AUXILIARY_TENANT_IDS` environment variable. When configuring from the environment, use a semicolon as a delimiter.
 - `client_certificate_password` (String, Sensitive) The password associated with the client certificate. For use when authenticating as a service principal using a client certificate. If not specified, value will be attempted to be read from the `ARM_CLIENT_CERTIFICATE_PASSWORD` environment variable.
 - `client_certificate_path` (String) The path to the client certificate associated with the service principal for use when authenticating as a service principal using a client certificate. If not specified, value will be attempted to be read from the `ARM_CLIENT_CERTIFICATE_PATH` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,5 +1,6 @@
 provider "alz" {
   lib_urls = [
-    "${path.root}/lib"
+    "${path.root}/lib",
+    "github.com/MyOrg/MyRepo//some/dir?ref=v1.1.0&depth=1",
   ]
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -68,6 +68,7 @@ type alzProviderData struct {
 
 // AlzProviderModel describes the provider data model.
 type AlzProviderModel struct {
+	AlzLibRef                 types.String `tfsdk:"alz_lib_ref"`
 	AllowLibOverwrite         types.Bool   `tfsdk:"allow_lib_overwrite"`
 	AuxiliaryTenantIds        types.List   `tfsdk:"auxiliary_tenant_ids"`
 	ClientCertificatePassword types.String `tfsdk:"client_certificate_password"`
@@ -196,6 +197,11 @@ func (p *AlzProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 				Optional:            true,
 			},
 
+			"alz_lib_ref": schema.StringAttribute{
+				MarkdownDescription: "The reference to the ALZ library to use. Default (for now) is `main`.",
+				Optional:            true,
+			},
+
 			"use_cli": schema.BoolAttribute{
 				MarkdownDescription: "Allow Azure CLI to be used for authentication. Default is `true`. If not specified, value will be attempted to be read from the `ARM_USE_CLI` environment variable.",
 				Optional:            true,
@@ -274,7 +280,7 @@ func (p *AlzProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	// Create the fs.FS library file systems based on the configuration.
 	urls := make([]string, 0)
 	if data.UseAlzLib.ValueBool() {
-		urls = append(urls, fmt.Sprintf(alzLibUrlFmtStr, alzLibRef))
+		urls = append(urls, fmt.Sprintf(alzLibUrlFmtStr, data.AlzLibRef.ValueString()))
 	}
 	if len(data.LibUrls.Elements()) != 0 {
 		// We turn the list of elements into a list of strings,
@@ -580,6 +586,11 @@ func configureDefaults(data *AlzProviderModel) {
 	// Do not allow library overwrite by default.
 	if data.AllowLibOverwrite.IsNull() {
 		data.AllowLibOverwrite = types.BoolValue(false)
+	}
+
+	// Set alzLibRef
+	if data.AlzLibRef.IsNull() {
+		data.AlzLibRef = types.StringValue(alzLibRef)
 	}
 }
 


### PR DESCRIPTION
Exposes provider attribute `alz_lib_ref`, used when downloading the ALZ policy library from Azure-Landing-Zones-Library