### PR TITLE
fix: alzlib 0.21.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/terraform-provider-alz
 go 1.23.1
 
 require (
-	github.com/Azure/alzlib v0.21.0
+	github.com/Azure/alzlib v0.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Azure/alzlib v0.21.0 h1:q80EDB47HUfDmqKuOU8jTjP2j1a35OrGskwLF/Gn51c=
-github.com/Azure/alzlib v0.21.0/go.mod h1:9AUD6m8ePsnpMu/olfX8CGsRO6HYvxUpl3KlchM6cS8=
+github.com/Azure/alzlib v0.21.1 h1:umAzl4TFkgp8k8U0K+lLCnHQ8iC+c04jbtydrb7EsC4=
+github.com/Azure/alzlib v0.21.1/go.mod h1:9AUD6m8ePsnpMu/olfX8CGsRO6HYvxUpl3KlchM6cS8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 h1:nyQWyZvwGTvunIMxi1Y9uXkcyr+I7TeNrr/foo4Kpk8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=


### PR DESCRIPTION
Fixes issue with role definition uniqueness where multiple instances of a definition are deployed in a tenant.

Note: will modify the name (uuid) of role definitions, and append the MG name to the end of the role name.