### PR TITLE
fix: conversion of resource and override selectors includes empty arrays rather than nil values

### DIFF
--- a/internal/provider/architecture_data_source.go
+++ b/internal/provider/architecture_data_source.go
@@ -330,22 +330,35 @@ func convertPolicyAssignmentOverridesToSdkType(ctx context.Context, input []gen.
 					"unable to convert override selectors attr.Value to concrete type",
 				)
 			}
-			in, err := frameworktype.SliceOfPrimitiveToGo[string](ctx, osv.In.Elements())
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"convertPolicyAssignmentOverridesToSdkType: error",
-					fmt.Sprintf("unable to convert OverrideSelctorsValue.In elements to Go slice: %s", err.Error()),
-				)
-				return nil
+
+			// Convert In to a go slice, start off from an uninitialized slice so that the value is nil if the input is empty.
+			var in []*string
+			if len(osv.In.Elements()) != 0 {
+				var err error
+				in, err = frameworktype.SliceOfPrimitiveToGo[string](ctx, osv.In.Elements())
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"convertPolicyAssignmentOverridesToSdkType: error",
+						fmt.Sprintf("unable to convert OverrideSelctorsValue.In elements to Go slice: %s", err.Error()),
+					)
+					return nil
+				}
 			}
-			notIn, err := frameworktype.SliceOfPrimitiveToGo[string](ctx, osv.NotIn.Elements())
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"convertPolicyAssignmentOverridesToSdkType: error",
-					fmt.Sprintf("unable to convert OverrideSelctorsValue.NotIn elements to Go slice: %s", err.Error()),
-				)
-				return nil
+
+			// Convert NotIn to a go slice, start off from an uninitialized slice so that the value is nil if the input is empty.
+			var notIn []*string
+			if len(osv.NotIn.Elements()) != 0 {
+				var err error
+				notIn, err = frameworktype.SliceOfPrimitiveToGo[string](ctx, osv.NotIn.Elements())
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"convertPolicyAssignmentOverridesToSdkType: error",
+						fmt.Sprintf("unable to convert OverrideSelctorsValue.NotIn elements to Go slice: %s", err.Error()),
+					)
+					return nil
+				}
 			}
+
 			selectors[j] = &armpolicy.Selector{
 				Kind:  to.Ptr(armpolicy.SelectorKind(osv.Kind.ValueString())),
 				In:    in,
@@ -376,22 +389,35 @@ func convertPolicyAssignmentResourceSelectorsToSdkType(ctx context.Context, inpu
 					"unable to convert resource selector selectors attr.Value to concrete type",
 				)
 			}
-			in, err := frameworktype.SliceOfPrimitiveToGo[string](ctx, rssv.In.Elements())
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"convertPolicyAssignmentResourceSelectorsToSdkType: error",
-					fmt.Sprintf("unable to convert ResourceSelectorSelectorsValue.In elements to Go slice: %s", err.Error()),
-				)
-				return nil
+
+			// Convert In to a go slice, start off from an uninitialized slice so that the value is nil if the input is empty.
+			var in []*string
+			if len(rssv.In.Elements()) != 0 {
+				var err error
+				in, err = frameworktype.SliceOfPrimitiveToGo[string](ctx, rssv.In.Elements())
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"convertPolicyAssignmentResourceSelectorsToSdkType: error",
+						fmt.Sprintf("unable to convert ResourceSelectorSelectorsValue.In elements to Go slice: %s", err.Error()),
+					)
+					return nil
+				}
 			}
-			notIn, err := frameworktype.SliceOfPrimitiveToGo[string](ctx, rssv.NotIn.Elements())
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"convertPolicyAssignmentResourceSelectorsToSdkType: error",
-					fmt.Sprintf("unable to convert ResourceSelectorSelectorsValue.NotIn elements to Go slice: %s", err.Error()),
-				)
-				return nil
+
+			// Convert NotIn to a go slice, start off from an uninitialized slice so that the value is nil if the input is empty.
+			var notIn []*string
+			if len(rssv.NotIn.Elements()) != 0 {
+				var err error
+				notIn, err = frameworktype.SliceOfPrimitiveToGo[string](ctx, rssv.NotIn.Elements())
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"convertPolicyAssignmentResourceSelectorsToSdkType: error",
+						fmt.Sprintf("unable to convert ResourceSelectorSelectorsValue.NotIn elements to Go slice: %s", err.Error()),
+					)
+					return nil
+				}
 			}
+
 			selectors[j] = &armpolicy.Selector{
 				Kind:  to.Ptr(armpolicy.SelectorKind(rssv.Kind.ValueString())),
 				In:    in,

--- a/internal/provider/architecture_data_source_test.go
+++ b/internal/provider/architecture_data_source_test.go
@@ -72,6 +72,7 @@ func TestAccAlzArchitectureDataSourceWithDefaultAndModify(t *testing.T) {
 					resource.TestCheckOutput("policy_assignment_resource_selector_name", "test-resource-selector"),
 					resource.TestCheckOutput("policy_assignment_resource_selector_kind", "resourceLocation"),
 					resource.TestCheckOutput("policy_assignment_resource_selector_in", "northeurope"),
+					resource.TestCheckOutput("policy_assignment_resource_selector_notin_should_be_null", "true"),
 				),
 			},
 		},
@@ -184,7 +185,7 @@ data "alz_architecture" "test" {
 					parameters = {
 						metricsEnabled = jsonencode({ value = false })
 					}
-					resource_selectors = [
+					resource_selectors	 = [
 						{
 							name = "test-resource-selector"
 							resource_selector_selectors = [
@@ -267,6 +268,10 @@ output "policy_assignment_resource_selector_kind" {
 
 output "policy_assignment_resource_selector_in" {
 	value = local.test_policy_assignment_decoded.properties.resourceSelectors[0].selectors[0].in[0]
+}
+
+output "policy_assignment_resource_selector_notin_should_be_null" {
+	value = lookup(local.test_policy_assignment_decoded.properties.resourceSelectors[0].selectors[0], "notIn", null) == null
 }
 `
 }


### PR DESCRIPTION
Fixes #150

Use uninitialised vars to ensure nil value if the length of the incoming Framework type is zero.

Updated existing test to ensure the field is not present.