### PR TITLE
feat!: latest alz library (2024.10.1) and alzlib (0.22.1)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ If this value is not specified, the default value will be used, which is:
 
 ```terraform
 alz_library_references = [
-  { path = "platform/alz", tag = "2024.07.5" },
+  { path = "platform/alz", tag = "2024.10.1" },
 ]
 ``` (see [below for nested schema](#nestedatt--library_references))
 - `oidc_request_token` (String, Sensitive) The bearer token for the request to the OIDC provider. For use when authenticating using OpenID Connect. If not specified, value will be attempted to be read from the first non-empty value of the `ARM_OIDC_REQUEST_TOKEN` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/terraform-provider-alz
 go 1.23.1
 
 require (
-	github.com/Azure/alzlib v0.21.7
+	github.com/Azure/alzlib v0.22.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Azure/alzlib v0.21.7 h1:njS2fxyWBep6WQw5SMY+F3wNfvi4yFGioPIr/teJKas=
-github.com/Azure/alzlib v0.21.7/go.mod h1:9AUD6m8ePsnpMu/olfX8CGsRO6HYvxUpl3KlchM6cS8=
+github.com/Azure/alzlib v0.22.1 h1:B0ehimJjUGqqCPisXai5wL0w11lH7YvyUe5R1IKBmVk=
+github.com/Azure/alzlib v0.22.1/go.mod h1:9AUD6m8ePsnpMu/olfX8CGsRO6HYvxUpl3KlchM6cS8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 h1:nyQWyZvwGTvunIMxi1Y9uXkcyr+I7TeNrr/foo4Kpk8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=

--- a/internal/provider/gen/alz_provider_gen.go
+++ b/internal/provider/gen/alz_provider_gen.go
@@ -105,8 +105,8 @@ func AlzProviderSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Description:         "A list of references to the [ALZ library](https://aka.ms/alz/library) to use. Each reference should either contain the `path` (e.g. `platform/alz`) and the `ref` (e.g. `2024.03.5`), or a `custom_url` to be supplied to go-getter.\nIf this value is not specified, the default value will be used, which is:\n\n```terraform\nalz_library_references = [\n  { path = \"platform/alz\", tag = \"2024.07.5\" },\n]\n```\n\n",
-				MarkdownDescription: "A list of references to the [ALZ library](https://aka.ms/alz/library) to use. Each reference should either contain the `path` (e.g. `platform/alz`) and the `ref` (e.g. `2024.03.5`), or a `custom_url` to be supplied to go-getter.\nIf this value is not specified, the default value will be used, which is:\n\n```terraform\nalz_library_references = [\n  { path = \"platform/alz\", tag = \"2024.07.5\" },\n]\n```\n\n",
+				Description:         "A list of references to the [ALZ library](https://aka.ms/alz/library) to use. Each reference should either contain the `path` (e.g. `platform/alz`) and the `ref` (e.g. `2024.03.5`), or a `custom_url` to be supplied to go-getter.\nIf this value is not specified, the default value will be used, which is:\n\n```terraform\nalz_library_references = [\n  { path = \"platform/alz\", tag = \"2024.10.1\" },\n]\n```\n\n",
+				MarkdownDescription: "A list of references to the [ALZ library](https://aka.ms/alz/library) to use. Each reference should either contain the `path` (e.g. `platform/alz`) and the `ref` (e.g. `2024.03.5`), or a `custom_url` to be supplied to go-getter.\nIf this value is not specified, the default value will be used, which is:\n\n```terraform\nalz_library_references = [\n  { path = \"platform/alz\", tag = \"2024.10.1\" },\n]\n```\n\n",
 				Validators: []validator.List{
 					listvalidator.UniqueValues(),
 				},

--- a/internal/provider/ir.json
+++ b/internal/provider/ir.json
@@ -127,7 +127,7 @@
           "name": "library_references",
           "list_nested": {
             "optional_required": "optional",
-            "description": "A list of references to the [ALZ library](https://aka.ms/alz/library) to use. Each reference should either contain the `path` (e.g. `platform/alz`) and the `ref` (e.g. `2024.03.5`), or a `custom_url` to be supplied to go-getter.\nIf this value is not specified, the default value will be used, which is:\n\n```terraform\nalz_library_references = [\n  { path = \"platform/alz\", tag = \"2024.07.5\" },\n]\n```\n\n",
+            "description": "A list of references to the [ALZ library](https://aka.ms/alz/library) to use. Each reference should either contain the `path` (e.g. `platform/alz`) and the `ref` (e.g. `2024.03.5`), or a `custom_url` to be supplied to go-getter.\nIf this value is not specified, the default value will be used, which is:\n\n```terraform\nalz_library_references = [\n  { path = \"platform/alz\", tag = \"2024.10.1\" },\n]\n```\n\n",
             "nested_object": {
               "attributes": [
                 {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -40,7 +40,7 @@ import (
 const (
 	userAgentBase = "AzureTerraformAlzProvider"
 	alzLibDirBase = ".alzlib"
-	alzLibRef     = "2024.07.5"
+	alzLibRef     = "2024.10.1"
 	alzLibPath    = "platform/alz"
 )
 


### PR DESCRIPTION
Update provider to use library default of `2024.10.1`

Update alzlib to latest of `0.22.1`