### PR TITLE
feat: allow using specified role definition name and rolename

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -68,6 +68,14 @@ make testacc
 
 **Note:** Acceptance tests read data from Azure and need a valid authorization context. You can log in using `az cli` to do this.
 
+## Generating the Provider Code
+
+The provider uses a JSON scheme to generate the provider code. This can be found in the [ir.json](/internal/provider/ir.json) file. If you make changes to this file, you can regenerate the provider code by running:
+
+```sh
+make generateprovider
+```
+
 ## Building The Provider
 
 1. Clone the repository

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,3 +30,9 @@ genprovider:
 	cd internal/provider
 	go generate
 	cd ../..
+
+.PHONY: generateprovider
+generateprovider:
+	go install
+	go install github.com/hashicorp/terraform-plugin-codegen-framework/cmd/tfplugingen-framework@latest
+	tfplugingen-framework generate all --input ./internal/provider/ir.json --output ./internal/provider/gen --package gen

--- a/internal/provider/gen/alz_provider_gen.go
+++ b/internal/provider/gen/alz_provider_gen.go
@@ -133,6 +133,11 @@ func AlzProviderSchema(ctx context.Context) schema.Schema {
 				Description:         "The path to a file containing an OIDC id token for use when authenticating using OpenID Connect. If not specified, value will be attempted to be read from the `ARM_OIDC_TOKEN_FILE_PATH` environment variable.",
 				MarkdownDescription: "The path to a file containing an OIDC id token for use when authenticating using OpenID Connect. If not specified, value will be attempted to be read from the `ARM_OIDC_TOKEN_FILE_PATH` environment variable.",
 			},
+			"role_definitions_use_supplied_names_enabled": schema.BoolAttribute{
+				Optional:            true,
+				Description:         "Whether to allow using the Name and RoleName supplied in the library directly for a predictable ID. Default behaviour is to update them to unique values per management group. Default is `false`.",
+				MarkdownDescription: "Whether to allow using the Name and RoleName supplied in the library directly for a predictable ID. Default behaviour is to update them to unique values per management group. Default is `false`.",
+			},
 			"skip_provider_registration": schema.BoolAttribute{
 				Optional:            true,
 				Description:         "Should the provider skip registering all of the resource providers that it supports, if they're not already registered? Default is `false`. If not specified, value will be attempted to be read from the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable.",
@@ -170,25 +175,26 @@ func AlzProviderSchema(ctx context.Context) schema.Schema {
 }
 
 type AlzModel struct {
-	AuxiliaryTenantIds                   types.List   `tfsdk:"auxiliary_tenant_ids"`
-	ClientCertificatePassword            types.String `tfsdk:"client_certificate_password"`
-	ClientCertificatePath                types.String `tfsdk:"client_certificate_path"`
-	ClientId                             types.String `tfsdk:"client_id"`
-	ClientSecret                         types.String `tfsdk:"client_secret"`
-	Environment                          types.String `tfsdk:"environment"`
-	LibraryFetchDependencies             types.Bool   `tfsdk:"library_fetch_dependencies"`
-	LibraryOverwriteEnabled              types.Bool   `tfsdk:"library_overwrite_enabled"`
-	LibraryReferences                    types.List   `tfsdk:"library_references"`
-	OidcRequestToken                     types.String `tfsdk:"oidc_request_token"`
-	OidcRequestUrl                       types.String `tfsdk:"oidc_request_url"`
-	OidcToken                            types.String `tfsdk:"oidc_token"`
-	OidcTokenFilePath                    types.String `tfsdk:"oidc_token_file_path"`
-	SkipProviderRegistration             types.Bool   `tfsdk:"skip_provider_registration"`
-	SuppressWarningPolicyRoleAssignments types.Bool   `tfsdk:"suppress_warning_policy_role_assignments"`
-	TenantId                             types.String `tfsdk:"tenant_id"`
-	UseCli                               types.Bool   `tfsdk:"use_cli"`
-	UseMsi                               types.Bool   `tfsdk:"use_msi"`
-	UseOidc                              types.Bool   `tfsdk:"use_oidc"`
+	AuxiliaryTenantIds                     types.List   `tfsdk:"auxiliary_tenant_ids"`
+	ClientCertificatePassword              types.String `tfsdk:"client_certificate_password"`
+	ClientCertificatePath                  types.String `tfsdk:"client_certificate_path"`
+	ClientId                               types.String `tfsdk:"client_id"`
+	ClientSecret                           types.String `tfsdk:"client_secret"`
+	Environment                            types.String `tfsdk:"environment"`
+	LibraryFetchDependencies               types.Bool   `tfsdk:"library_fetch_dependencies"`
+	LibraryOverwriteEnabled                types.Bool   `tfsdk:"library_overwrite_enabled"`
+	LibraryReferences                      types.List   `tfsdk:"library_references"`
+	OidcRequestToken                       types.String `tfsdk:"oidc_request_token"`
+	OidcRequestUrl                         types.String `tfsdk:"oidc_request_url"`
+	OidcToken                              types.String `tfsdk:"oidc_token"`
+	OidcTokenFilePath                      types.String `tfsdk:"oidc_token_file_path"`
+	RoleDefinitionsUseSuppliedNamesEnabled types.Bool   `tfsdk:"role_definitions_use_supplied_names_enabled"`
+	SkipProviderRegistration               types.Bool   `tfsdk:"skip_provider_registration"`
+	SuppressWarningPolicyRoleAssignments   types.Bool   `tfsdk:"suppress_warning_policy_role_assignments"`
+	TenantId                               types.String `tfsdk:"tenant_id"`
+	UseCli                                 types.Bool   `tfsdk:"use_cli"`
+	UseMsi                                 types.Bool   `tfsdk:"use_msi"`
+	UseOidc                                types.Bool   `tfsdk:"use_oidc"`
 }
 
 var _ basetypes.ObjectTypable = LibraryReferencesType{}

--- a/internal/provider/ir.json
+++ b/internal/provider/ir.json
@@ -15,6 +15,13 @@
           }
         },
         {
+          "name": "role_definitions_use_supplied_names_enabled",
+          "bool": {
+            "optional_required": "optional",
+            "description": "Whether to allow using the Name and RoleName supplied in the library directly for a predictable ID. Default behaviour is to update them to unique values per management group. Default is `false`."
+          }
+        },
+        {
           "name": "auxiliary_tenant_ids",
           "list": {
             "element_type": {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -375,6 +375,7 @@ func configureAlzLib(token *azidentity.ChainedTokenCredential, data gen.AlzModel
 	opts := &alzlib.AlzLibOptions{
 		AllowOverwrite: data.LibraryOverwriteEnabled.ValueBool(),
 		Parallelism:    10,
+		UniqueRoleDefinitions: !data.RoleDefinitionsUseSuppliedNamesEnabled.ValueBool(),
 	}
 	alz := alzlib.NewAlzLib(opts)
 	cf, err := armpolicy.NewClientFactory("", token, popts)


### PR DESCRIPTION
Allow using the name and role name specified in the library to support migration