### PR TITLE
fix: 32-bit builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - run: go build -v .
         env:
           GOOS: linux
-          GOARCH: 386
+          GOARCH: '386'
 
       - name: Run linters
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,31 @@ jobs:
           go-version-file: "go.mod"
           cache: true
       - run: go mod download
+
       - run: go build -v .
+
+      - name: Run linters
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        with:
+          version: latest
+
+  build32:
+    name: Build (32-bit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - run: go mod download
+
+      - run: go build -v .
+        env:
+          GOOS: linux
+          GOARCH: 386
+
       - name: Run linters
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -131,7 +131,7 @@ func (p *AlzProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		return
 	}
 
-	r := rand.Intn(math.MaxUint32)
+	r := rand.Intn(math.MaxInt32)
 	alzlib.Instance.Store(uint32(r))
 	tflog.Debug(ctx, "Stored random ID for AlzLib instance", map[string]interface{}{
 		"instance": r,


### PR DESCRIPTION
This pull request makes a minor update to the random number generation in the `Configure` method of the `AlzProvider`. The change ensures that the random number generated fits within the expected range for storing the instance.

* Changed the call to `rand.Intn` from using `math.MaxUint32` to `math.MaxInt32` to ensure the generated random number fits within int type on 32-bit systems.